### PR TITLE
ReadableStream parse input

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbushell/xml-streamify",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "exports": {
     ".": "./mod.ts",
     "./node": "./src/node.ts",

--- a/examples/deno.ts
+++ b/examples/deno.ts
@@ -17,7 +17,8 @@ const blog = async () => {
 
 const podcast = async () => {
   const contoller = new AbortController();
-  const parser = parse('https://feed.syntax.fm/rss', {
+  const response = await fetch('https://feed.syntax.fm/rss');
+  const parser = parse(response.body!, {
     signal: contoller.signal
   });
   const items: Node[] = [];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,7 +16,7 @@ const ignoreTypes: Partial<Record<NodeType, keyof ParseOptions>> = {
 
 /**
  * Async generator function for parsing a streamed XML document
- * @param input    URL to fetch and parse or a ReadableStream
+ * @param input    URL to fetch and parse (or a ReadableStream)
  * @param options  Parsing options {@link ParseOptions}
  * @returns Yields parsed XML nodes {@link Node}
  */


### PR DESCRIPTION
For issue  #1 - this PR allows an optional `ReadableStream` input to the `parse` function instead of a URL.

Current URL example:
```js
const parser = parse('https://feed.syntax.fm/rss');
```

Stream example:
```js
const response = await fetch('https://feed.syntax.fm/rss');
const parser = parse(response.body);
```

I've updated the Deno example to use both.